### PR TITLE
was not creating function map properly for anonymous function callbacks

### DIFF
--- a/adrJSBridge.js
+++ b/adrJSBridge.js
@@ -123,17 +123,10 @@ var adr = function() {
         } else
         {
             var maxIndex = __functionIndexMap[funcName];
-            var callbackFuncStr = callbackFunc.toString();
-            for (var i = 0; i <= maxIndex; i++)
-            {
-                var tmpName = funcName + i;
-                if (window[tmpName].toString() == callbackFuncStr)
-                    return tmpName;
-            }
-
-            var newIndex = ++__functionIndexMap[funcName];
-            window[funcName+newIndex] = callbackFunc;
-            return funcName+newIndex;
+            var newIndex = maxIndex + 1;
+            var tmpName = funcName+newIndex;
+            window[tmpName] = callbackFunc;
+            return tmpName;
         }
     };
     var _createIFrame = function(src) {


### PR DESCRIPTION
I think I have tracked down the root of your problem.  Your create callback function has two usecases it supports:
1. Passing in named functions on the global scope.  We don't have an issue here in our app but I think you have a bug here too. This is how you use your test harness which could be why you don't see the issue we are having.  If _createCallbackFunction is passed a named function it just returns that func name to be run.  I think this will actually fail though if you passed in a named function not on the global context.  You should really test this as it would mean when someone passed in a named inline function it would just fail b/c it could not find the function when it attempted to run the callback.

**Example:**

```
<html>
<head>
<script>
function onSuccess(response){};
function onError(ret){};

//This works bc your _createCallbackFunction just returns the name of "onSuccess" or "onError" and assumes the functions are on the global context which they are here.
function sendMailEncoded() {
    adr.sendEmailEncoded("test@gmail.com", "", "test subject", "test body", onSuccess, onError);
}

//This will work as your _createCallbackFunction just returns the name of "otherSuccess" or "otherError" and assumes the functions are on the global context.
adr.sendEmailEncoded("test@test.com", "", "test subject", "test body", function otherSuccess(){}, function otherError(){});
</script>
</head>
</html>

```
1. Passing in an anonymous function.  This is our approach as we have local functional scope that matters on each run.  Your _createCallbackFunction tries to handle this but I think it is doing it incorrectly.  I need you to verify that my thinking is correct.  Anytime the _createCallbackFunction is called it 'should' be creating a new function in the window function map.  It needs to do this because of functional scope.  It can't return an older copy of the function because that function's functional scope is different.  It should find the maximum index used so far in the window map and increment that by 1 to add the new function to the map.  In the old code, if you walked through it as if you were going to call it twice for the same anon function you will see that it would have never created a new mapped function.  If no function exists it would add it to the window map.  On the second call it says "Hey I already have it mapped so I need to map a new one!".  However, the old code would then do a loop (starting at 0) and then look for a function mapped on the window at that index for our callback and always return the one it orignally mapped.  It would never get passed the if block at line 130.  In my code, it always adds a new mapped function to the window map which I think is desired so that every call into this thing maintains its functional scope when later called as a callback.

Maybe there is another reason it is written the way it is today and I don't want to break any of that functionality for sure but just mentally walking through your old code I can see how it would ever work.
